### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,8 @@
     "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.2.2",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/server/src/api/routes/SalaRoutes.ts
+++ b/server/src/api/routes/SalaRoutes.ts
@@ -1,7 +1,16 @@
 import { Router } from 'express';
 import authMiddleware from '../middleware/authModdleware';
 import SalaController from '../controllers/SalaController';
+import rateLimit from 'express-rate-limit';
 const sala = Router();
+
+// Rate limiter configuration: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+sala.use(limiter);
 sala.use(authMiddleware);
 sala.get(`/`, SalaController.getAllSala);
 sala.post(`/newSala`, SalaController.createSala );


### PR DESCRIPTION
Fixes [https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/1](https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/1)

To fix the problem, we will add a rate-limiting middleware to the Express router. We will use the `express-rate-limit` package to set up a rate limiter that restricts the number of requests a client can make to the server within a specified time window. This will help prevent abuse and mitigate the risk of DoS attacks.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `server/src/api/routes/SalaRoutes.ts` file.
3. Configure the rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the router to ensure all routes are protected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
