### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/src/api/routes/ReservacionRoutes.ts
+++ b/server/src/api/routes/ReservacionRoutes.ts
@@ -1,9 +1,18 @@
 import { Router } from "express";
 import ReservacionController from "../controllers/ReservacionController";
 import authMiddleware from "../middleware/authModdleware";
+import rateLimit from "express-rate-limit";
+
 const reservacion = Router();
 
+// Rate limiting middleware
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 reservacion.use(authMiddleware);
+reservacion.use(limiter);
 reservacion.get("/", ReservacionController.getAllSala);
 reservacion.post("/newReservacion", ReservacionController.createReservacion);
 


### PR DESCRIPTION
Fixes [https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/2](https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/2)

To fix the problem, we will add a rate-limiting middleware to the Express router. We will use the `express-rate-limit` package to limit the number of requests a client can make to the server within a specified time window. This will help prevent DoS attacks by ensuring that no single client can overwhelm the server with too many requests.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `ReservacionRoutes.ts` file.
3. Configure the rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the router.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
