### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/src/api/routes/ReservacionRoutes.ts
+++ b/server/src/api/routes/ReservacionRoutes.ts
@@ -11,8 +11,8 @@ const limiter = rateLimit({
   max: 100, // limit each IP to 100 requests per windowMs
 });
 
-reservacion.use(authMiddleware);
 reservacion.use(limiter);
+reservacion.use(authMiddleware);
 reservacion.get("/", ReservacionController.getAllSala);
 reservacion.post("/newReservacion", ReservacionController.createReservacion);
 


### PR DESCRIPTION
Fixes [https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/4](https://github.com/CARLOSMARES/entrevista-lion-intel/security/code-scanning/4)

To fix the problem, we need to ensure that the rate limiting middleware is applied before the `authMiddleware`. This will ensure that the rate limiting is enforced before any potentially expensive authorization operations are performed. We will move the `reservacion.use(limiter);` line to be before the `reservacion.use(authMiddleware);` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
